### PR TITLE
Refine docs with science workflow examples

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,15 +9,13 @@ build:
       - python -m sphinx.ext.apidoc -o docs/source/api -f --separate --module-first src/matensemble src/matensemble/dynopro src/matensemble/redis
     build:
       html:
-        - uv run --group dev make -C docs html
+        - python -m sphinx -b html docs/source docs/build/html
         - mkdir -p "$READTHEDOCS_OUTPUT/html"
         - cp -R docs/build/html/. "$READTHEDOCS_OUTPUT/html/"
 
 python:
   install:
-    - method: uv
-      command: pip
-      requirements: docs/requirements.txt
+    - requirements: docs/requirements.txt
 
 sphinx:
   configuration: docs/source/conf.py

--- a/README.md
+++ b/README.md
@@ -11,7 +11,58 @@
 
 MatEnsemble is a framework to build, orchestrate, and asynchronously manage extremely scalable adaptive-learning workflows, especially targeted for compute-intensive AI-driven high-throughput and ensemble-driven materials modeling simulations (e.g., atomistic modeling, Phase-Field, etc.) as efficiently as possible. 
 
-While it can in general run on your personal Mac/Linux workstation and orchestrate arbitrary python callables, shell commands with explicit resource and dependency-aware execution graphs from a single python workflow driver process,  MatEnsemble shines with ***user-defined autonomous strategic*** execution of large batches of adaptively and hierarchically-scheduled tasks on HPC systems, often on Peta and Exascale computing facilities, e.g., Perlmutter, Frontier, Aurora etc.
+While it can in general run on your personal Mac/Linux workstation and orchestrate arbitrary python callables, shell commands with explicit resource and dependency-aware execution graphs from a single python workflow driver process,  MatEnsemble shines with ***user-defined autonomous strategic*** execution of large batches of adaptively and hierarchically-scheduled tasks on HPC systems, specifically on Peta and Exascale computing facilities, e.g., Perlmutter, Frontier, Aurora etc.
+
+## minimal code example
+
+MatEnsemble workflows are ordinary Python scripts (and/or shell commands) which can be use to: 1. define resource-aware chores, 2. pass chore outputs into later chores to create a DAG, and 3. add a strategy when the workflow should decide what to launch next while the campaign is already running.
+
+```python
+from matensemble.pipeline import Pipeline
+from matensemble.model import Resources
+from matensemble.chore import ChoreSpec
+
+pipe = Pipeline()
+
+md_resources = dict(num_tasks=128, cores_per_task=1, gpus_per_task=4, mpi=True)
+analysis_resources = dict(num_tasks=1, cores_per_task=8)
+
+
+@pipe.chore(name="simulate", **md_resources)
+def simulate(candidate):
+    # Run LAMMPS, DFT, phase-field, or another science application here.
+    return {"trajectory": "traj.dump", "candidate": candidate}
+
+
+@pipe.chore(name="score", **analysis_resources)
+def score(simulation):
+    # Analyze the completed simulation and propose the next high-value sample.
+    return {
+        "uncertainty": 0.18,
+        "next_candidate": {"temperature": 1750, "composition": "SiO2"},
+    }
+
+
+@pipe.strategy(bolo_list=["score"], **analysis_resources)
+def adapt(report):
+    if report["uncertainty"] < 0.05:
+        return None
+
+    return ChoreSpec(
+        args=(report["next_candidate"],),
+        kwargs={},
+        resources=Resources(**md_resources),
+        qualname="simulate",
+    )
+
+
+seed = {"temperature": 1600, "composition": "SiO2"}
+trajectory = simulate(seed)
+score(trajectory)  # OutputReference creates the simulate -> score DAG edge.
+
+future = pipe.submit(log_delay=10)
+results = future.result()
+```
 
 ## Installation
 For general installation see our [documentation](https://matensemble.readthedocs.io/en/latest/)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,4 +2,5 @@ sphinx>=9.1.0
 sphinx-autodoc-typehints>=3.6.2
 sphinx-rtd-theme>=3.1.0
 myst-parser>=5.0.0
-
+cloudpickle>=3.1.2
+networkx>=3.6.1

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,6 +50,7 @@ napoleon_numpy_docstring = True
 autodoc_mock_imports = [
     "flux",
     "flux.job",
+    "flux.job.executor",
     "mpi4py",
     "mpi4py.MPI",
     "lammps",

--- a/docs/source/mcp.rst
+++ b/docs/source/mcp.rst
@@ -62,7 +62,7 @@ After it is configured you are free to use the agent to start building MatEnsemb
 workflows.
 
 Visual Studio Code
------------------
+------------------
 
 Along with the CLI configuartions there is a configuration for Visual Studio Code to launch the
 MCP server. You can launch it by from the Command Pallete, "MCP: Server List" and you should see
@@ -95,7 +95,7 @@ There is an interactive dashboard which allows you to veiw the status of all pas
 workflows in the campaign directory. There is a prompt which is provided by the MCP server
 to launch the dashboard. Simply ask the agent:
 
-.. code-block:: txt
+.. code-block:: text
 
    Can you use the MatEnsemble MCP server to launch the dashboard and give me the command to access it from localhost?
 

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -125,11 +125,11 @@ inspect the result of a completed :class:`~matensemble.chore.Chore`, create one 
 :class:`~matensemble.chore.ChoreSpec` objects, and add those chores to the submission queue while the workflow
 is still running.
 
-Here is an example of adding a strategy to a chore:
+Here is an example of adding a strategy to a materials campaign. The first simulation and analysis form a
+normal DAG edge through :class:`~matensemble.model.OutputReference`; the strategy then decides whether to add
+another simulation while the workflow is still running.
 
 .. code-block:: python
-
-    import random
 
     from matensemble.chore import ChoreSpec
     from matensemble.model import Resources
@@ -137,59 +137,45 @@ Here is an example of adding a strategy to a chore:
 
     pipe = Pipeline()
 
-    @pipe.chore()
-    def generate_num():
-        return random.randint(1, 1000)
+    md_resources = dict(num_tasks=128, cores_per_task=1, gpus_per_task=4, mpi=True)
+    analysis_resources = dict(num_tasks=1, cores_per_task=8)
 
-    @pipe.chore()
-    def fizz(n):
-        print(f"{n} is divisible by 3")
-        print("fizz")
+    @pipe.chore(name="run_md", **md_resources)
+    def run_md(candidate):
+        # Launch LAMMPS, DFT, phase-field, or another science code here.
+        return {"candidate": candidate, "trajectory": "trajectory.dump"}
 
-    @pipe.chore()
-    def buzz(n):
-        print(f"{n} is divisible by 5")
-        print("buzz")
+    @pipe.chore(name="analyze_structure", **analysis_resources)
+    def analyze_structure(simulation):
+        # Compute descriptors, uncertainty, stability, diffraction, etc.
+        return {
+            "candidate": simulation["candidate"],
+            "uncertainty": 0.18,
+            "next_candidate": {"temperature": 1750, "composition": "SiO2"},
+        }
 
-    @pipe.chore()
-    def fizzbuzz(n):
-        print(f"{n} is divisible by 3 and 5")
-        print("fizzbuzz")
+    @pipe.strategy(bolo_list=["analyze_structure"], **analysis_resources)
+    def refine_campaign(report):
+        if report["uncertainty"] < 0.05:
+            return None
 
-    @pipe.strategy(bolo_list=["generate_num"])
-    def proc_strat(results_of_finished_chore):
-        if results_of_finished_chore % 15 == 0:
-            return ChoreSpec(
-                args=(results_of_finished_chore,),
-                kwargs=None,
-                resources=Resources(),
-                qualname="fizzbuzz",
-            )
-        if results_of_finished_chore % 5 == 0:
-            return ChoreSpec(
-                args=(results_of_finished_chore,),
-                kwargs=None,
-                resources=Resources(),
-                qualname="buzz",
-            )
-        if results_of_finished_chore % 3 == 0:
-            return ChoreSpec(
-                args=(results_of_finished_chore,),
-                kwargs=None,
-                resources=Resources(),
-                qualname="fizz",
-            )
-        print(f"{results_of_finished_chore} is not divisible by 3 or 5")
+        return ChoreSpec(
+            args=(report["next_candidate"],),
+            kwargs={},
+            resources=Resources(**md_resources),
+            qualname="run_md",
+        )
 
-    for _ in range(10):
-        generate_num()
+    seed = {"temperature": 1600, "composition": "SiO2"}
+    trajectory = run_md(seed)
+    analyze_structure(trajectory)
 
     pipe.submit()
 
-The :obj:`bolo_list` tells the manager which chores it should be on the lookout for. Whenever the manager sees a
-``generate_num`` chore instance complete, it can spawn the user-defined strategy as a new chore. This strategy can
-optionally return a :obj:`matensemble.chore.ChoreSpec`, which will spawn a new chore with the specified args,
-kwargs, and resources (cores, GPUs, MPI, etc.).
+The :obj:`bolo_list` tells the manager which chores it should monitor for strategy callbacks. Whenever an
+``analyze_structure`` chore instance completes, MatEnsemble can launch the user-defined strategy as a new chore.
+If that strategy returns a :obj:`matensemble.chore.ChoreSpec`, the specified callable, arguments, and resources
+(cores, GPUs, MPI, etc.) are added to the live queue.
 
 Roadmap and stability
 =====================

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -142,78 +142,66 @@ provides another decorator to do this.
     from matensemble.model import Resources
     from matensemble.pipeline import Pipeline
     from matensemble.chore import ChoreSpec
-    import random
 
     pipe = Pipeline()
 
+    screen_resources = dict(num_tasks=1, cores_per_task=1)
+    validation_resources = dict(num_tasks=1, cores_per_task=4)
 
-    # Define a chore to simply guess a number between an upper and lower limit.
-    # This could be some science case trying to fit some parameters, etc.
-    @pipe.chore()
-    def guess(lower: int, upper: int, guess_num: int = 1) -> dict:
-        """Guesses a number between the bottom and top of the range"""
-
+    @pipe.chore(name="screen_candidate", **screen_resources)
+    def screen_candidate(candidate):
+        """Cheap proxy for a simulation or surrogate-model evaluation."""
+        temperature = candidate["temperature"]
         return {
-            "guess": ((lower + upper) // 2),
-            "low": lower,
-            "high": upper,
-            "num_guesses": guess_num,
+            "candidate": candidate,
+            "formation_energy": ((temperature - 1500) ** 2) / 1_000_000,
         }
 
-    # I'm thinking of a number between {a} and {b}.
-    a, b = 1, 100
-    answer = random.randint(a, b)
+    @pipe.chore(name="analyze_screen", **screen_resources)
+    def analyze_screen(screen):
+        """Decide whether this candidate deserves a more expensive validation."""
+        energy = screen["formation_energy"]
+        return {
+            "candidate": screen["candidate"],
+            "formation_energy": energy,
+            "uncertainty": 0.12 if energy < 0.03 else 0.02,
+        }
 
-    @pipe.strategy(bolo_list=["guess"])
-    def higher_or_lower(guess_result):
-        """
-        Takes the results of a 'guess' chore and spawns a new guess chore based on
-        the results
-        """
+    @pipe.chore(name="validate_candidate", **validation_resources)
+    def validate_candidate(candidate):
+        """Placeholder for a larger MD, DFT, or phase-field validation run."""
+        return {"candidate": candidate, "validation_status": "submitted"}
 
-        if guess_result["guess"] == answer:
-            print(
-                f"Godd Job! I was thinking of {answer},",
-                f"and you got it in {guess_result['num_guesses']}",
-            )
-        elif guess_result["guess"] < answer:
-            return ChoreSpec(
-                args=(
-                    guess_result["guess"] + 1,
-                    guess_result["high"],
-                    guess_result["num_guesses"] + 1,
-                ),
-                kwargs=None,
-                resources=Resources(),
-                qualname="guess",
-            )
-        else:
-            return ChoreSpec(
-                args=(
-                    guess_result["low"],
-                    guess_result["guess"] - 1,
-                    guess_result["num_guesses"] + 1,
-                ),
-                kwargs=None,
-                resources=Resources(),
-                qualname="guess",
-            )
+    @pipe.strategy(bolo_list=["analyze_screen"], **screen_resources)
+    def request_validation(report):
+        """Spawn validation only for uncertain, high-value candidates."""
+        if report["uncertainty"] <= 0.05:
+            return None
 
-    guess(a, b)
+        return ChoreSpec(
+            args=(report["candidate"],),
+            kwargs={},
+            resources=Resources(**validation_resources),
+            qualname="validate_candidate",
+        )
+
+    for temperature in (1400, 1500, 1700):
+        candidate = {"composition": "SiO2", "temperature": temperature}
+        screen = screen_candidate(candidate)
+        analyze_screen(screen)
+
     future = pipe.submit(log_delay=1)
     print(future.result())
 
 
-The :meth:`~matensemble.pipline.Pipeline.strategy` can be thought of as adding a callback to a
-:class:`~matensemble.chore.Chore` But this function has access to the internal
+The :meth:`~matensemble.pipeline.Pipeline.strategy` can be thought of as adding a callback to a
+:class:`~matensemble.chore.Chore`. This function has access to the internal
 :class:`~matensemble.manager.FluxManager` queue. If this strategy function returns a
 :class:`~matensemble.chore.ChoreSpec` then it will be added to the matensemble queue at runtime.
 This lets you create workflows that expand dynamically.
 
-The BOLO_list is a list of chores that you are telling the manager to Be On the Look-Out for. If
-one of these chores completes then the manager will see it and say "HEY! You're a wanted criminal"
-and spawn your strategy passing the results of the completed chore that was in the BOLO list to the
-strategy as an argument.
+The ``bolo_list`` is the list of chore names that should trigger the strategy. If one of these chores completes,
+MatEnsemble launches the strategy and passes the completed chore result as an argument.
 
 User-defined strategies can observe completed chores and dynamically add more work by returning
 :class:`~matensemble.chore.ChoreSpec` objects.


### PR DESCRIPTION
## Summary
- Replace toy examples with science-driven workflow examples for dependency-aware DAGs, resource-aware execution, and adaptive strategies.
- Add a minimal README code block that showcases MatEnsemble's orchestration model.
- Keep the Read the Docs build fixes needed for the docs-only build path.

## Verification
- `python -m sphinx.ext.apidoc -o docs/source/api -f --separate --module-first src/matensemble src/matensemble/dynopro src/matensemble/redis`
- `python -m sphinx -W --keep-going -b html docs/source docs/build/html-pr-test`
- `timeout 90s flux start -s 2 python science_strategy_proxy.py`
