### PR TITLE
Add adaptive LAMMPS example workflow

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -13,6 +13,7 @@ Example directories
 * ``generic/mpi`` — portable, site-independent MPI-enabled Python chores.
 * ``generic/strategy`` — portable, site-independent adaptive strategy and ``ChoreSpec``.
 * ``generic/executable`` — portable, site-independent executable chores using ``Pipeline.exec``.
+* ``generic/lammps_adaptive`` — portable LAMMPS Python-module campaign with dependency-aware analysis and adaptive validation.
 * ``frontier/lammps_smoke`` — Frontier LAMMPS GPU smoke workflow and CLI batch scripts.
 * ``pathfinder/lammps_smoke`` — Pathfinder LAMMPS CPU smoke workflow and CLI batch scripts.
 * ``perlmutter/lammps_smoke`` — Perlmutter LAMMPS GPU smoke workflow and CLI batch scripts.

--- a/example_workflows/generic/README.md
+++ b/example_workflows/generic/README.md
@@ -11,6 +11,14 @@ Python workflow pattern here with that system's launch instructions and examples
 
 MatEnsemble workflows are centered around `Chores` which are delayed function calls that are serialized and later called on compute resources that MatEnsemble has control over
 
+Available examples:
+
+- `dependencies`: dependency-aware Python chores using `OutputReference`.
+- `executable`: external command chores through `Pipeline.exec`.
+- `mpi`: portable MPI-enabled Python chores.
+- `strategy`: adaptive `ChoreSpec` spawning.
+- `lammps_adaptive`: a tiny LAMMPS Python-module campaign with adaptive validation.
+
 ## Dev container and local Flux runs
 
 Inside the repository dev container, run these examples with a multi-rank Flux test instance:

--- a/example_workflows/generic/lammps_adaptive/README.md
+++ b/example_workflows/generic/lammps_adaptive/README.md
@@ -1,0 +1,25 @@
+# Adaptive LAMMPS Smoke Campaign
+
+This example runs a tiny Lennard-Jones LAMMPS campaign through MatEnsemble.
+It is meant for testing the science workflow shape, not for production
+materials conclusions.
+
+The workflow demonstrates:
+
+- a resource-aware LAMMPS simulation chore,
+- a dependent analysis chore that receives the LAMMPS result through an
+  `OutputReference`,
+- a user strategy that spawns validation LAMMPS runs for promising screen
+  results while the workflow is still running.
+
+Run it inside the repository dev container or another Flux-capable environment
+with the LAMMPS Python module installed:
+
+```bash
+flux start -s 2 python example_workflows/generic/lammps_adaptive/workflow.py
+```
+
+The script writes normal MatEnsemble output under a timestamped
+`matensemble_workflow-*` directory. Validation LAMMPS chores also write
+`final.data` and `final.dump` in their per-chore work directories for quick
+inspection.

--- a/example_workflows/generic/lammps_adaptive/workflow.py
+++ b/example_workflows/generic/lammps_adaptive/workflow.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from matensemble.chore import ChoreSpec
+from matensemble.model import Resources
+from matensemble.pipeline import Pipeline
+
+
+pipe = Pipeline()
+
+LJ_RESOURCE_SPEC = dict(num_tasks=1, cores_per_task=1)
+ANALYSIS_RESOURCE_SPEC = dict(num_tasks=1, cores_per_task=1)
+
+LJ_RESOURCES = Resources(**LJ_RESOURCE_SPEC)
+
+
+def _run_lj_relaxation(
+    *,
+    temperature: float,
+    seed: int,
+    steps: int,
+    stage: str,
+    write_artifacts: bool = False,
+    parent_temperature: float | None = None,
+) -> dict:
+    """Run a small CPU Lennard-Jones LAMMPS relaxation."""
+
+    from lammps import lammps
+
+    lmp = lammps(cmdargs=["-screen", "none", "-log", "none"])
+    try:
+        for command in [
+            "units lj",
+            "atom_style atomic",
+            "boundary p p p",
+            "lattice fcc 0.8442",
+            "region box block 0 5 0 5 0 5",
+            "create_box 1 box",
+            "create_atoms 1 box",
+            "mass 1 1.0",
+            "pair_style lj/cut 2.5",
+            "pair_coeff 1 1 1.0 1.0 2.5",
+            "neighbor 0.3 bin",
+            "neigh_modify every 1 delay 0 check yes",
+            "thermo_modify norm yes",
+        ]:
+            lmp.command(command)
+
+        lmp.command(
+            f"velocity all create {temperature:.6f} {seed} "
+            "mom yes rot yes dist gaussian"
+        )
+        lmp.command("fix integrate all nve")
+        lmp.command(f"run {steps}")
+
+        if write_artifacts:
+            lmp.command("write_data final.data")
+            lmp.command("write_dump all custom final.dump id type x y z")
+
+        return {
+            "kind": "lammps_result",
+            "stage": stage,
+            "temperature": temperature,
+            "parent_temperature": parent_temperature,
+            "seed": seed,
+            "steps": steps,
+            "atoms": int(lmp.get_natoms()),
+            "pe_per_atom": float(lmp.get_thermo("pe")),
+            "ke_per_atom": float(lmp.get_thermo("ke")),
+            "final_temperature": float(lmp.get_thermo("temp")),
+        }
+    finally:
+        lmp.close()
+
+
+@pipe.chore(name="run_lj_screen", **LJ_RESOURCE_SPEC)
+def run_lj_screen(temperature: float, seed: int) -> dict:
+    """Run an inexpensive LAMMPS screen point."""
+
+    return _run_lj_relaxation(
+        temperature=temperature,
+        seed=seed,
+        steps=40,
+        stage="screen",
+    )
+
+
+@pipe.chore(name="score_lj_screen", **ANALYSIS_RESOURCE_SPEC)
+def score_lj_screen(lammps_result: dict) -> dict:
+    """Score a screen result and decide whether to launch validation."""
+
+    pe = lammps_result["pe_per_atom"]
+    validate = lammps_result["stage"] == "screen" and pe <= -5.85
+    return {
+        "kind": "score",
+        "temperature": lammps_result["temperature"],
+        "seed": lammps_result["seed"],
+        "pe_per_atom": pe,
+        "score": -pe,
+        "decision": "validate" if validate else "stop",
+        "reason": (
+            "low relaxed potential energy"
+            if validate
+            else "screen point did not pass validation threshold"
+        ),
+    }
+
+
+@pipe.chore(name="validate_lj_state", **LJ_RESOURCE_SPEC)
+def validate_lj_state(score: dict) -> dict:
+    """Rerun a promising state longer with a different seed."""
+
+    return _run_lj_relaxation(
+        temperature=max(0.1, score["temperature"] + 0.05),
+        seed=score["seed"] + 1009,
+        steps=80,
+        stage="validation",
+        write_artifacts=True,
+        parent_temperature=score["temperature"],
+    )
+
+
+@pipe.strategy(
+    bolo_list=["score_lj_screen"],
+    name="request_validation",
+    **ANALYSIS_RESOURCE_SPEC,
+)
+def request_validation(score: dict) -> ChoreSpec | None:
+    """Spawn a validation LAMMPS chore for promising score results."""
+
+    if score["decision"] != "validate":
+        return None
+
+    return ChoreSpec(
+        args=(score,),
+        kwargs=None,
+        qualname="validate_lj_state",
+        resources=LJ_RESOURCES,
+    )
+
+
+for index, temperature in enumerate([0.70, 1.00, 1.30, 1.60], start=1):
+    screen = run_lj_screen(temperature, seed=87000 + index)
+    score_lj_screen(screen)
+
+
+future = pipe.submit(log_delay=1)
+results = future.result()
+
+scores = [
+    result
+    for result in results.values()
+    if isinstance(result, dict) and result.get("kind") == "score"
+]
+validations = [
+    result
+    for result in results.values()
+    if isinstance(result, dict)
+    and result.get("kind") == "lammps_result"
+    and result.get("stage") == "validation"
+]
+
+print(f"screened_temperatures={sorted(score['temperature'] for score in scores)}")
+print(
+    "validated_from_temperatures="
+    f"{sorted(result['parent_temperature'] for result in validations)}"
+)
+print(
+    "best_screen_pe_per_atom="
+    f"{min(score['pe_per_atom'] for score in scores):.6f}"
+)
+
+if not validations:
+    raise RuntimeError("Expected at least one adaptive LAMMPS validation chore.")


### PR DESCRIPTION
## Summary
- Add a portable `generic/lammps_adaptive` workflow that runs a small Lennard-Jones LAMMPS campaign through MatEnsemble.
- Demonstrate dependency-aware `run_lj_screen -> score_lj_screen` analysis and strategy-driven validation with `ChoreSpec`.
- Document the new example in the generic examples README and docs examples index.

## Verification
- `flux start -s 2 python example_workflows/generic/lammps_adaptive/workflow.py`
- `python -m sphinx.ext.apidoc -o docs/source/api -f --separate --module-first src/matensemble src/matensemble/dynopro src/matensemble/redis && python -m sphinx -W --keep-going -b html docs/source docs/build/html-lammps-example-test`
- Direct MCP example-discovery assertion for `generic/lammps_adaptive`
